### PR TITLE
PLAT-65: Fix for circular referencing in API introspection

### DIFF
--- a/oap-ws-api-ws/src/test/java/oap/ws/api/TestRecursiveWS.java
+++ b/oap-ws-api-ws/src/test/java/oap/ws/api/TestRecursiveWS.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) Open Application Platform Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package oap.ws.api;
+
+import oap.ws.WsMethod;
+
+import static oap.http.server.nio.HttpServerExchange.HttpMethod.GET;
+
+public class TestRecursiveWS {
+
+    @WsMethod( method = GET, path = "/getRecursiveObject" )
+    public SomeClass methodWithRecursiveObject( ) {
+        return new SomeClass();
+    }
+
+    public class SomeClass {
+        public OtherClass otherObject;
+    }
+
+    public class OtherClass {
+        public SomeClass someObject;
+    }
+
+}

--- a/oap-ws-api-ws/src/test/resources/META-INF/oap-module.conf
+++ b/oap-ws-api-ws/src/test/resources/META-INF/oap-module.conf
@@ -5,4 +5,9 @@ services {
     implementation = oap.ws.api.ExampleWS
     ws-service.path = example
   }
+
+  recursion {
+    implementation = oap.ws.api.TestRecursiveWS
+    ws-service.path = recursion
+  }
 }

--- a/oap-ws-api-ws/src/test/resources/oap/ws/api/ApiWSTest/api.txt
+++ b/oap-ws-api-ws/src/test/resources/oap/ws/api/ApiWSTest/api.txt
@@ -1,4 +1,23 @@
 ################################################################################
+Service oap.ws.api.TestRecursiveWS
+Bound to recursion
+Methods:
+	Method methodWithRecursiveObject
+	[GET] /recursion/getRecursiveObject
+	Produces application/json
+	Realm param <unsecure>
+	Permissions <unsecure>
+	Returns SomeClass
+			{
+				otherObject: OtherClass
+				{
+					someObject: <Recursive Reference>
+				}
+			}
+	No parameters
+
+
+################################################################################
 Service oap.ws.api.ExampleWS
 Bound to example
 Methods:

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     </distributionManagement>
 
     <properties>
-        <oap-ws.project.version>17.11.4.0</oap-ws.project.version>
+        <oap-ws.project.version>17.11.4.1</oap-ws.project.version>
         <oap.deps.oap.version>17.10.28.2</oap.deps.oap.version>
 
         <oap.deps.assertj.version>3.12.2</oap.deps.assertj.version>


### PR DESCRIPTION
Fixes an issue where any circular reference in any object returned by a web service method breaks the recursive walk of the  web service api in `/system/api` functionality with an infinite loop and stack overflow error. The fix checks if any object has been rendered as part of the object tree before. If it has, then the rendering for that branch is terminated with a message `Recursive Reference`.